### PR TITLE
Session 6: Implement database schema + seed

### DIFF
--- a/packages/api/src/db/schema.test.ts
+++ b/packages/api/src/db/schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { sites, challenges, attempts, profiles } from './schema';
+
+describe('Database Schema', () => {
+  it('sites table is defined with all required columns', () => {
+    expect(sites).toBeDefined();
+    expect(sites.id).toBeDefined();
+    expect(sites.siteKey).toBeDefined();
+    expect(sites.siteSecret).toBeDefined();
+    expect(sites.allowedOrigins).toBeDefined();
+    expect(sites.tier).toBeDefined();
+    expect(sites.active).toBeDefined();
+    expect(sites.createdAt).toBeDefined();
+  });
+
+  it('challenges table has FK to sites', () => {
+    expect(challenges).toBeDefined();
+    expect(challenges.siteId).toBeDefined();
+  });
+
+  it('attempts table has FKs to challenges and sites', () => {
+    expect(attempts).toBeDefined();
+    expect(attempts.challengeId).toBeDefined();
+    expect(attempts.siteId).toBeDefined();
+  });
+
+  it('profiles table has unique constraint', () => {
+    expect(profiles).toBeDefined();
+    expect(profiles.siteId).toBeDefined();
+    expect(profiles.externalUserId).toBeDefined();
+    expect(profiles.platform).toBeDefined();
+  });
+});

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -1,10 +1,59 @@
 // Database schema for RhythmGuard
-// Full schema defined in IMPLEMENTATION_SPEC.md section 1.5
-// Implement in session 4
+// Session 4 — Database + Sites
+// Source of truth: IMPLEMENTATION_SPEC.md section 1.5
 
-import { pgTable, uuid, text, integer, real, boolean, timestamp, jsonb } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, integer, real, boolean, timestamp, jsonb, unique } from 'drizzle-orm/pg-core';
 
-// TODO: Session 4 — Implement sites, challenges, attempts, profiles tables
-// See IMPLEMENTATION_SPEC.md section 1.5 for exact schema
+export const sites = pgTable('sites', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull(),
+  siteKey: text('site_key').notNull().unique(),      // rg_live_xxxx (public, sent by widget)
+  siteSecret: text('site_secret').notNull().unique(), // rg_secret_xxxx (private, server-to-server)
+  allowedOrigins: jsonb('allowed_origins').notNull(), // string[]
+  tier: text('tier').notNull().default('community'),  // 'community' | 'enterprise'
+  active: boolean('active').default(true),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
 
-export {};
+export const challenges = pgTable('challenges', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  siteId: uuid('site_id').references(() => sites.id).notNull(),
+  difficulty: integer('difficulty').notNull(),
+  sequence: jsonb('sequence').notNull(),
+  signature: text('signature').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  expiresAt: timestamp('expires_at').notNull(),
+  attemptsUsed: integer('attempts_used').default(0).notNull(),
+  maxAttempts: integer('max_attempts').default(3).notNull(),
+  status: text('status').default('active').notNull(), // 'active' | 'completed' | 'expired' | 'escalated'
+});
+
+export const attempts = pgTable('attempts', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  challengeId: uuid('challenge_id').references(() => challenges.id).notNull(),
+  siteId: uuid('site_id').references(() => sites.id).notNull(),
+  externalUserId: text('external_user_id'),  // Nullable (community tier)
+  platform: text('platform').notNull(),       // 'desktop' | 'mobile'
+  features: jsonb('features').notNull(),       // Computed features (anonymized)
+  decision: text('decision').notNull(),        // 'accept' | 'escalate' | 'fallback'
+  botProbability: real('bot_probability').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const profiles = pgTable('profiles', {   // Enterprise only
+  id: uuid('id').primaryKey().defaultRandom(),
+  siteId: uuid('site_id').references(() => sites.id).notNull(),
+  externalUserId: text('external_user_id').notNull(),
+  platform: text('platform').notNull(),
+  baseline: jsonb('baseline').notNull(),        // Encrypted: AES-256-GCM
+  enrollmentComplete: boolean('enrollment_complete').default(false),
+  enrollmentSessions: integer('enrollment_sessions').default(0),
+  calibrationVersion: integer('calibration_version').default(1),
+  decayStatus: text('decay_status').default('active'),
+  decayThresholdDays: integer('decay_threshold_days').default(90),
+  lastActiveAt: timestamp('last_active_at').defaultNow(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => ({
+  uniqueUserPlatform: unique().on(table.siteId, table.externalUserId, table.platform),
+}));

--- a/packages/api/src/db/seed.ts
+++ b/packages/api/src/db/seed.ts
@@ -2,7 +2,46 @@
 // Creates default site: rg_test_dev123 / rg_secret_dev456
 // Run: pnpm db:seed
 
-// TODO: Session 4 — Implement seed with sites table
-// See IMPLEMENTATION_SPEC.md section 1.5
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { sites } from './schema';
+import { eq } from 'drizzle-orm';
 
-console.log('Seed script not yet implemented. See session 4.');
+const seedData = {
+  name: 'RhythmGuard Development',
+  siteKey: 'rg_test_dev123',
+  siteSecret: 'rg_secret_dev456',
+  allowedOrigins: ['http://localhost:3000', 'http://localhost:5173'],
+  tier: 'community' as const,
+  active: true,
+};
+
+async function seed() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+
+  const client = postgres(connectionString);
+  const db = drizzle(client);
+
+  const existing = await db.select().from(sites).where(eq(sites.siteKey, seedData.siteKey));
+  if (existing.length > 0) {
+    console.log('Development site already exists, skipping seed.');
+    await client.end();
+    process.exit(0);
+  }
+
+  await db.insert(sites).values(seedData);
+  console.log('✓ Development site created successfully.');
+  console.log(`  siteKey: ${seedData.siteKey}`);
+  console.log(`  siteSecret: ${seedData.siteSecret}`);
+
+  await client.end();
+}
+
+seed().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
# Session 6: Database + Sites

## Schema (packages/api/src/db/schema.ts)
- **sites**: id(uuid), name, siteKey(unique), siteSecret(unique), allowedOrigins(jsonb), tier, active, createdAt
- **challenges**: id(uuid), siteId(FK→sites), difficulty, sequence(jsonb), signature, createdAt, expiresAt, attemptsUsed, maxAttempts, status
- **attempts**: id(uuid), challengeId(FK→challenges), siteId(FK→sites), externalUserId, platform, features(jsonb), decision, botProbability, createdAt
- **profiles**: id(uuid), siteId(FK→sites), externalUserId, platform, baseline(jsonb), enrollmentComplete, enrollmentSessions, calibrationVersion, decayStatus, decayThresholdDays, lastActiveAt, createdAt, updatedAt + unique(siteId,externalUserId,platform)

## Seed (packages/api/src/db/seed.ts)
Creates dev site: &#x2A;*rg_test_dev123** / **rg_secret_dev456**

## Tests (packages/api/src/db/schema.test.ts)
Validates all tables are defined with required columns.

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Vitest checks to verify database schema objects and required fields.

* **Refactor**
  * Implemented the core database schema: tables, relationships, defaults, constraints, and uniqueness rules.

* **Chores**
  * Added a development seed script to create or verify a local site record and report results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->